### PR TITLE
Html strings and numeral names. 

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/lib/gviz.dart
+++ b/lib/gviz.dart
@@ -11,7 +11,12 @@ class Gviz {
     'strict'
   ];
 
-  static final _validName = RegExp(r'^[a-zA-Z_][a-zA-Z_\d]*$');
+  static final _validStringID = RegExp(
+    r'^[a-zA-Z\200-\377_][a-zA-Z\200-\377_\d]*$',
+  );
+  static final _validNumeralID = RegExp(
+    r'^-?(\.\d+|\d+(.\d*)?)$',
+  );
 
   final String _name;
   final Map<String, String> _nodeProperties;
@@ -29,9 +34,26 @@ class Gviz {
         _edgeProperties = edgeProperties ?? const {},
         _nodeProperties = nodeProperties ?? const {},
         _graphProperties = graphProperties ?? const {} {
-    if (!_validName.hasMatch(_name)) {
+    if (!_isValidID(_name)) {
       throw ArgumentError.value(name, 'name', '`name` must be a simple name.');
     }
+  }
+
+  bool _isValidID(String input) {
+    if (_validStringID.hasMatch(input) &&
+        !_keywords.contains(input.toLowerCase())) {
+      return true;
+    }
+
+    if (_validNumeralID.hasMatch(input)) {
+      return true;
+    }
+
+    if (input.startsWith('<') && input.endsWith('>')) {
+      return true;
+    }
+
+    return input.length > 3 && input.startsWith('"') && input.endsWith('"');
   }
 
   /// Returns `true` if [addNode] has been called with [nodeName].
@@ -59,8 +81,7 @@ class Gviz {
 
   void write(StringSink sink) {
     String escape(String input) {
-      if (_validName.hasMatch(input) &&
-          !_keywords.contains(input.toLowerCase())) {
+      if (_isValidID(input)) {
         return input;
       }
 

--- a/test/gviz_test.dart
+++ b/test/gviz_test.dart
@@ -76,14 +76,14 @@ void main() {
 beans";
   "node" [xlabel=keyword];
   "node" -> "edge";
-  "42" [xlabel="starts with number"];
-  "42" -> "node";
+  42 [xlabel="starts with number"];
+  42 -> "node";
   _5fine [xlabel="no special characters"];
-  _5fine -> "42";
-  "\"quotes\"" [xlabel="contains double quotes"];
-  "\"quotes\"" -> _5fine;
+  _5fine -> 42;
+  "quotes" [xlabel="contains double quotes"];
+  "quotes" -> _5fine;
   "'quotes'" [xlabel="contains single quotes"];
-  "'quotes'" -> "\"quotes\"";
+  "'quotes'" -> "quotes";
   "cool
 beans" [xlabel="contains a newline"];
   "cool

--- a/test/gviz_test.dart
+++ b/test/gviz_test.dart
@@ -55,6 +55,7 @@ void main() {
       'node': 'keyword',
       '42': 'starts with number',
       '_5fine': 'no special characters',
+      '<xml>': 'html string',
       '"quotes"': 'contains double quotes',
       "'quotes'": 'contains single quotes',
       'cool\nbeans': 'contains a newline'
@@ -80,8 +81,10 @@ beans";
   42 -> "node";
   _5fine [xlabel="no special characters"];
   _5fine -> 42;
+  <xml> [xlabel="html string"];
+  <xml> -> _5fine;
   "quotes" [xlabel="contains double quotes"];
-  "quotes" -> _5fine;
+  "quotes" -> <xml>;
   "'quotes'" [xlabel="contains single quotes"];
   "'quotes'" -> "quotes";
   "cool


### PR DESCRIPTION
### Use case
I would like to use [HTML-like labels](https://www.graphviz.org/doc/info/shapes.html#html) in gviz. Package does not have that behavior by default, and also have issues with already quoted strings and numeral ids. Specifications allow to use this [list of features](https://www.graphviz.org/doc/info/lang.html#ids)

### Proposal
Add support for HTML strings, numeral ids. Remove escape for already quoted strings